### PR TITLE
Fix editor closing bug

### DIFF
--- a/project/src/ui/code_editor/MainWindow.gd
+++ b/project/src/ui/code_editor/MainWindow.gd
@@ -29,8 +29,13 @@ func _init_TextEditor():
 	#textEditor.minimap_width = 150
 	
 
+# Function that hides the editor when its closed with a dedicated button
 func _on_close() -> void:
-	queue_free()
+	set_visible(false)
+	
+# Function that displays the hidden editor	
+func enableEditor() -> void:
+	set_visible(true)
 
 # Function to handle dropdown menu button options
 # Options to open and save file


### PR DESCRIPTION
Now the editor keeps the entered text even after being closed and reopened